### PR TITLE
feat: Add support for removing TODO's from Pull Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![License](https://img.shields.io/github/license/rohit-gohri/danger-plugin-todos)](https://github.com/rohit-gohri/danger-plugin-todos/blob/master/LICENSE.md)
 
-A [danger-js](https://danger.systems/js/) plugin to list all todos/fixmes/etc added/changed in a PR.
+A [danger-js](https://danger.systems/js/) plugin to list all todos/fixmes/etc added/changed/removed in a PR.
 
 ## Intro to Danger
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -144,16 +144,16 @@ describe("todos()", () => {
   describe("prepareTodosForDanger()", () => {
     it("should return added todo's", () => {
       const keywordMatches = {"TODO": []}
-      prepareTodosForDanger(["TODO"], "TODO: Added", "", "file.md", ()=>"https://example.com", keywordMatches)
+      const matches = prepareTodosForDanger(["TODO"], "TODO: Added", "", "file.md", ()=>"https://example.com", keywordMatches)
 
       expect(keywordMatches).toStrictEqual({"TODO": ["``TODO: Added``: [file.md](https://example.com)"]})
     })
 
     it("should return removed todo's", () => {
       const keywordMatches = {"TODO": []}
-      prepareTodosForDanger(["TODO"], "", "TODO: Removed", "file.md", ()=>"https://example.com", keywordMatches)
+      const matches = prepareTodosForDanger(["TODO"], "", "TODO: Removed", "file.md", ()=>"https://example.com", keywordMatches)
 
-      expect(keywordMatches).toStrictEqual({"TODO": ["~~TODO: Removed~~: [file.md](https://example.com)"]})
+      expect(matches).toStrictEqual({"TODO": ["~~TODO: Removed~~: [file.md](https://example.com)"]})
     })
   })
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import todos, { getMatches } from "./index"
+import todos, {getMatches, prepareTodosForDanger} from "./index"
 
 declare const global: any
 
@@ -138,6 +138,22 @@ describe("todos()", () => {
       )
       expect(matches.length).toBe(1)
       expect(matches).toMatchSnapshot()
+    })
+  })
+
+  describe("prepareTodosForDanger()", () => {
+    it("should return added todo's", () => {
+      const keywordMatches = {"TODO": []}
+      prepareTodosForDanger(["TODO"], "TODO: Added", "", "file.md", ()=>"https://example.com", keywordMatches)
+
+      expect(keywordMatches).toStrictEqual({"TODO": ["``TODO: Added``: [file.md](https://example.com)"]})
+    })
+
+    it("should return removed todo's", () => {
+      const keywordMatches = {"TODO": []}
+      prepareTodosForDanger(["TODO"], "", "TODO: Removed", "file.md", ()=>"https://example.com", keywordMatches)
+
+      expect(keywordMatches).toStrictEqual({"TODO": ["~~TODO: Removed~~: [file.md](https://example.com)"]})
     })
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export function getFormattedSrcLink(filepath: string, repoUrl?: RepoUrl) {
   return srcLink
 }
 
-export function prepareTodosForDanger(keywords: string[] | undefined, addedText: string, removedText: string, filepath: string, repoUrl: string | ((filepath: string) => string) | undefined | boolean, keywordMatches: PlainObject<string[]>) {
+export function prepareTodosForDanger(keywords: string[] | undefined, addedText: string, removedText: string, filepath: string, repoUrl: RepoUrl, keywordMatches: PlainObject<string[]>) {
   if (keywords === undefined) return
   keywords.forEach(keyword => {
     const addedMatches = getMatches(addedText, keyword)

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,9 @@ export default async function todos({
       catch (err) {
         if (danger.gitlab) {
           // Could not get diff, will be using full file
-          addedText = await danger.gitlab.utils.fileContents(filepath)
+          const fileContent = await danger.gitlab.utils.fileContents(filepath)
+          addedText = fileContent
+          removedText = fileContent
         }
         else {
           throw err


### PR DESCRIPTION
## This introduce new feature for showing Removed TODO's from Pull Request.

### How it will look now? 

Removed will look like this:
~~TODO: Removed~~: [file.md](https://example.com)

Added will look like this: 
``TODO: Added``: [file.md](https://example.com)


## This fixes #4 

Any feedback is welcome 🎉