### PR TITLE
Change commit hash reference to the latest one instead of the first one

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export function getFormattedSrcLink(filepath: string, repoUrl?: RepoUrl) {
   }
   // Github style url
   if (typeof repoUrl === "string") {
-    srcLink = `[${filepath}](${repoUrl}/blob/${danger.git.commits[0].sha}/${filepath})`
+    srcLink = `[${filepath}](${repoUrl}/blob/${danger.git.commits.slice(-1)[0].sha}/${filepath})`
   } else if (typeof repoUrl === "function") {
     srcLink = `[${filepath}](${repoUrl(filepath)})`
   }


### PR DESCRIPTION
Suppose the first commit's hash is `commitFirst` and the latest commit's hash is `commitLatest.`
When you add a TODO tag to your file, you will see the link to the blob file with the first commit hash instead of the latest one.

Your URL will be like this:
```
http://github.com/your/repository/blob/commitFirst/yourFile.ts
```

But, it should be like:
```
http://github.com/your/repository/blob/commitLatest/yourFile.ts
```